### PR TITLE
Change address part delimiter

### DIFF
--- a/bldg-client/Assets/_Scripts/BldgController.cs
+++ b/bldg-client/Assets/_Scripts/BldgController.cs
@@ -166,13 +166,13 @@ public class BldgController : MonoBehaviour
 	string generateNewAddress(string oldAddress, int newX, int newY) {
 		// generate new address based on new coordinates
 		Debug.Log("Old address is: " + oldAddress);
-		string[] addressParts = oldAddress.Split('-');
+		string[] addressParts = oldAddress.Split(AddressUtils.DELIM_CHAR);
 		string[] newAddressParts = new string[addressParts.Length];
 		for (int i = 0; i < addressParts.Length - 1; i++) {
 			newAddressParts[i] = addressParts[i];
 		}
 		newAddressParts[newAddressParts.Length - 1] = "b(" + newX + "," + newY + ")";
-		return string.Join("-", newAddressParts);
+		return string.Join(AddressUtils.DELIM, newAddressParts);
 	}
 
 	public void completeRelocatingBldg(Vector3 point) {

--- a/bldg-client/Assets/_Scripts/ResidentController.cs
+++ b/bldg-client/Assets/_Scripts/ResidentController.cs
@@ -83,6 +83,9 @@ public class ResidentController : MonoBehaviour
                     move_x = moveX,
                     move_y = moveY
                 });
+                resident.location = moveLocation;
+                resident.x = moveX;
+                resident.y = moveY;
             }
         }
     }

--- a/bldg-client/Assets/_Scripts/Utils.cs
+++ b/bldg-client/Assets/_Scripts/Utils.cs
@@ -9,8 +9,8 @@ using System;
 namespace Utils {
 	public class AddressUtils {
 
-		public static readonly string DELIM = "-";
-		public static readonly char DELIM_CHAR = '-';
+		public static readonly string DELIM = "/";
+		public static readonly char DELIM_CHAR = '/';
 		public static readonly char[] DELIM_CHAR_ARRAY = { DELIM_CHAR };
 
 
@@ -55,7 +55,7 @@ namespace Utils {
 
 		public static string generateInsideAddress(string addr) {
 			if (isBldg (addr)) {
-				addr = addr + "-l0";
+				addr = addr + DELIM_CHAR + "l0";
 			}
 			return addr;
 		}


### PR DESCRIPTION
## Why
The original bldg address schema had `-` as the delimiter between the address parts. This caused issues when an address part had a negative number (e.g., `g-b(-123,456)`), for naiive address parsers that split the address by the `-` delimiter (such as the parsers I created..)

## What
Changing the bldg address schema to use `/` as the parts delimiter, e.g.:
`g-b(123,456)-l0-b(30,10)-l2` -> `g/b(123,456)/l0/b(30,10)/l2`
