### PR TITLE
Disabled the use of WASD keys for movement

### DIFF
--- a/bldg-client/ProjectSettings/InputManager.asset
+++ b/bldg-client/ProjectSettings/InputManager.asset
@@ -11,8 +11,8 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: left
     positiveButton: right
-    altNegativeButton: a
-    altPositiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -27,8 +27,8 @@ InputManager:
     descriptiveNegativeName: 
     negativeButton: down
     positiveButton: up
-    altNegativeButton: s
-    altPositiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: 0.001
     sensitivity: 3

--- a/bldg-client/ProjectSettings/ProjectSettings.asset
+++ b/bldg-client/ProjectSettings/ProjectSettings.asset
@@ -146,7 +146,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Standalone: com.DefaultCompany.bldg-client
+    Standalone: com.fromTeal.bldg-client
   buildNumber:
     Standalone: 0
     iPhone: 0


### PR DESCRIPTION
## Why
When typing in the chat the WASD keys, the avatar would move, which isn't the intention of the user

## What
Disabled the use of WASD as movement keys