### PR TITLE
quick fix by limiting the chat history

### DIFF
--- a/bldg-client/Assets/_Scenes/g.unity
+++ b/bldg-client/Assets/_Scenes/g.unity
@@ -606,7 +606,7 @@ MonoBehaviour:
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
     GateFit: 2
-    m_SensorSize: {x: 1.6865315, y: 1}
+    m_SensorSize: {x: 1.9362245, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 0
@@ -3744,6 +3744,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0672c8373a96b42b29b36a2257c2744c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CHAT_HISTORY_SIZE: 25
   ChatInputField: {fileID: 1438347856}
   ChatDisplayOutput: {fileID: 17415392}
   ChatHistoryDisplay: {fileID: 557951614}

--- a/bldg-client/Assets/_Scripts/BldgController.cs
+++ b/bldg-client/Assets/_Scripts/BldgController.cs
@@ -128,7 +128,7 @@ public class BldgController : MonoBehaviour
 
     public void handleLongClick(BldgObject bldgObject, Bldg bldgModel, Vector3 position) {
         Debug.Log("long click on: " + bldgModel.name);
-		showContextMenu();
+		//showContextMenu();
     }
 
     public void handleRightClick(Bldg model, Vector3 position) {

--- a/bldg-client/Assets/_Scripts/ChatUIController.cs
+++ b/bldg-client/Assets/_Scripts/ChatUIController.cs
@@ -9,7 +9,7 @@ using Models;
 
 public class ChatUIController : MonoBehaviour {
 
-    public int CHAT_HISTORY_SIZE = 10;
+    public int CHAT_HISTORY_SIZE = 25;
 
     public TMP_InputField ChatInputField;
 

--- a/bldg-client/Assets/_Scripts/ChatUIController.cs
+++ b/bldg-client/Assets/_Scripts/ChatUIController.cs
@@ -9,6 +9,7 @@ using Models;
 
 public class ChatUIController : MonoBehaviour {
 
+    public int CHAT_HISTORY_SIZE = 10;
 
     public TMP_InputField ChatInputField;
 
@@ -66,8 +67,17 @@ public class ChatUIController : MonoBehaviour {
             return 0;
         });
 
+        int toSkip = 0;
+        if (chatHistory.Count > CHAT_HISTORY_SIZE) {
+            toSkip = chatHistory.Count - CHAT_HISTORY_SIZE;
+        }
         ChatDisplayOutput.text = string.Empty;
         foreach (SayAction m in chatHistory) {
+            if (toSkip > 0) {
+                toSkip--;
+                continue;
+            }
+            Debug.Log("Rendering message");
             string formattedInput = formatMessage(m.say_speaker, m.say_text);
             if (ChatDisplayOutput.text == string.Empty)
                 ChatDisplayOutput.text = formattedInput;


### PR DESCRIPTION
## Why
Chat history scroll isn't working well.

## What
Limiting the amount of messages in chat history to 25, as a quick workaround. 
Proper fix would be to understand how to properly use the scrollbar, which currently doesn't adjust to the content.
Also, removed the context menu wheel, as it's not configure yet.